### PR TITLE
Add support for conditionally installing showdown extension initializers

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const map = stew.map;
 
 module.exports = {
   name: 'ember-highlightjs-shim',
+
   included(app, parentAddon) {
     var target = (parentAddon || app);
     this._super.included.apply(this, arguments);
@@ -16,6 +17,12 @@ module.exports = {
     this.importOption(target);
     this.importCss(target);
     this.importJs(target);
+
+    this._enabledExtensions = [];
+
+    if (shouldImportShowdownShim(app, parentAddon)) {
+      this._enabledExtensions.push('showdown');
+    }
   },
 
   importOption(target) {
@@ -34,6 +41,16 @@ module.exports = {
       production: 'vendor/highlightjs/highlight.pack.min.js'
     });
     target.import('vendor/shims/highlight.js');
+  },
+
+  treeForApp(tree) {
+    let thisDir = path.dirname(module.filename);
+    let extensions = new Funnel(path.join(thisDir, 'vendor', 'initializers'), {
+      include: this._enabledExtensions.map((name) => `${name}.js`),
+      destDir: 'initializers'
+    });
+
+    return mergeTrees([extensions, tree], { overwrite: true });
   },
 
   treeForVendor(vendorTree) {
@@ -55,6 +72,14 @@ module.exports = {
     trees.push(hlJs);
     return map(mergeTrees(trees), (content) => content);
   },
-
-
 };
+
+function shouldImportShowdownShim(app, parentAddon) {
+  var config = app.project.config(app.env).highlightJS || {};
+  var isShowdownIncluded = [parentAddon, app]
+    .some((target) => target &&
+      Object.keys(target.dependencies()).includes('ember-cli-showdown'));
+
+  return isShowdownIncluded && config.includeShowdown !== false ||
+    config.includeShowdown === true;
+}

--- a/vendor/initializers/showdown.js
+++ b/vendor/initializers/showdown.js
@@ -1,0 +1,41 @@
+import showdown from 'showdown';
+import hljs from 'highlight';
+
+let matchAny = `(?:.|\\s)*?`;
+let query = new RegExp(`((?:<pre${matchAny}>\\s*)?<code${matchAny}(?:\\s+class\\s*=\\s*(["'])(?:.*?\\s+)?(?:language-(.*?))?(?:\\2|\\s)${matchAny})?>)((?:.|\\s)*?)(<\\/code>(?:<\\/pre>)?)`, 'gi');
+
+// todo: consider contrib'ing to ember-highlightjs-shim: https://github.com/rennomarcus/ember-highlightjs-shim/blob/master/index.js
+// alternately, showdown-highlight
+
+export function initialize() {
+  showdown.extension('highlight', function () {
+    return [{
+      type: 'output',
+      filter(html) {
+        return html.replace(query, function(
+          match,
+          left,
+          _quotationMark,
+          languageName,
+          source,
+          right
+        ) {
+          if (source) {
+            let { value } = languageName ?
+              hljs.highlight(languageName, source) :
+              hljs.highlightAuto(source);
+
+            return `${left}${value}${right}`;
+          } else {
+            return match;
+          }
+        });
+      }
+    }];
+  });
+}
+
+export default {
+  name: 'highlightjs-showdown-extension',
+  initialize
+};


### PR DESCRIPTION
@rennomarcus This PR adds the initializer I shared (featuring an artisanal, hand-crafted regex) as `vendor/initializers/showdown.js`.

In `index.js`, we:

- Create an empty `_enabledExtensions` array;
- Push `showdown` into the array, if the user has installed `ember-cli-showdown`, or has explicitly opted in via `config/environment`; and
- Funnel all named initializers from `vendor/initializers/${name}.js` into the app tree's `initializers` dir, allowing the app tree to overwrite in case of confict.